### PR TITLE
Implementazione tema chiaro/scuro

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Default filters for file extensions and folders (e.g., skip `.env`, `node_modules`, `.git`, etc.)
 - Saves and loads user settings to/from a JSON file
 - Option to format output as Markdown with code blocks, headings, and file separators
+- Switch between dark and light mode, saved in settings and applied to the GUI and browser preview
 
 ## Requirements
 

--- a/promptpack/settings.py
+++ b/promptpack/settings.py
@@ -11,6 +11,7 @@ DEFAULT_SETTINGS = {
     "as_markdown": True,
     "include_heading": True,
     "use_code_block": True,
+    "theme": "dark",
 }
 
 
@@ -18,7 +19,8 @@ def load_settings():
     if Path(SETTINGS_FILE).exists():
         try:
             with open(SETTINGS_FILE, "r", encoding="utf-8") as f:
-                return json.load(f)
+                data = json.load(f)
+                return {**DEFAULT_SETTINGS, **data}
         except Exception:
             return DEFAULT_SETTINGS.copy()
     return DEFAULT_SETTINGS.copy()

--- a/promptpack_settings.json
+++ b/promptpack_settings.json
@@ -18,5 +18,6 @@
     ],
     "as_markdown": true,
     "include_heading": true,
-    "use_code_block": true
+    "use_code_block": true,
+    "theme": "dark"
 }


### PR DESCRIPTION
## Sommario
- aggiunta nuova impostazione `theme`
- applicazione tema alla GUI e alla preview web
- aggiornamento README e file di configurazione

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870dfb57fd483218c7f174a52e423ab